### PR TITLE
Fix TypeError: Access GroupDetails attributes using dot notation

### DIFF
--- a/app/routers/report/report.py
+++ b/app/routers/report/report.py
@@ -218,7 +218,7 @@ async def download_balance(
         access_token_details=access_token_details,
     )
     user_with_debt = ""
-    for user in general_data["group_details"]["users_with_debt"]:
+    for user in general_data["group_details"].users_with_debt or []:
         user_with_debt += user.replace("DEPTO", "")
 
     data = {


### PR DESCRIPTION
## Description
Fixes TypeError in `download_balance` function where `GroupDetails` object was being accessed with subscript notation instead of dot notation.

## Changes
- Changed `general_data["group_details"]["users_with_debt"]` to `general_data["group_details"].users_with_debt`
- Added safety check `or []` to handle cases where `users_with_debt` might be `None`

## Testing
✅ Code formatting passed (`./cmd.sh format`)  
✅ QA checks passed (`./cmd.sh qa`)  
✅ Type checking passed (mypy)

## Related Issue
Closes #6

## Root Cause
The `get_parsed_data` function returns a dictionary where `group_details` is a `GroupDetails` Pydantic BaseModel object, not a dictionary. Attempting to use subscript notation on a Pydantic model raises `TypeError: 'GroupDetails' object is not subscriptable`.